### PR TITLE
Changing version of cluster-logging operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # example.com/grafanacloud-operator-bundle:$VERSION and example.com/grafanacloud-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/yoza/grafanacloud-operator
+IMAGE_TAG_BASE ?= quay.io/opdev/grafanacloud-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/grafanacloud-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafanacloud-operator.clusterserviceversion.yaml
@@ -162,7 +162,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/yoza/grafanacloud-operator:1.0.1
+                image: quay.io/opdev/grafanacloud-operator:1.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,4 +2,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: cluster-logging
-      version: "5.2.2-21"
+      version: "5.3.0-55"

--- a/catalogsource.yaml
+++ b/catalogsource.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/yoza/grafanacloud-operator-index:1.0.1
+  image: quay.io/opdev/grafanacloud-operator-index:1.0.1
   displayName: Test Operators
   publisher: Red Hat Partner


### PR DESCRIPTION
- Bumping Red Hat Openshift Logging Operator version to `5.3.0-55` in `dependency.yaml`
- Migrating controller, bundle and index image to `opdev` repository on [quay.io](https://quay.io/)